### PR TITLE
Make InteractiveBase abstract

### DIFF
--- a/Discord.Addons.Interactive/InteractiveBase.cs
+++ b/Discord.Addons.Interactive/InteractiveBase.cs
@@ -7,11 +7,11 @@ using Discord.WebSocket;
 
 namespace Discord.Addons.Interactive
 {
-    public class InteractiveBase : InteractiveBase<SocketCommandContext>
+    public abstract class InteractiveBase : InteractiveBase<SocketCommandContext>
     {
     }
 
-    public class InteractiveBase<T> : ModuleBase<T>
+    public abstract class InteractiveBase<T> : ModuleBase<T>
         where T : SocketCommandContext
     {
         public InteractiveService Interactive { get; set; }


### PR DESCRIPTION
Not something that's a massive problem but earlier in the Discord.Net channel someone was trying to create a new instance of `InteractiveBase` and access its methods. This change just makes it more consistent with `ModuleBase` and `ModuleBase<T>` but also explicitly shows that the class is intended to be inherited.