### PR TITLE
Fixed null references in InteractiveService

### DIFF
--- a/Discord.Addons.Interactive/InteractiveService.cs
+++ b/Discord.Addons.Interactive/InteractiveService.cs
@@ -17,9 +17,10 @@ namespace Discord.Addons.Interactive
 
         // helpers to allow DI containers to resolve without a custom factory
         public InteractiveService(DiscordSocketClient discord, InteractiveServiceConfig config = null)
-            => new InteractiveService((BaseSocketClient)discord, config);
+            : this((BaseSocketClient)discord, config) {}
+            
         public InteractiveService(DiscordShardedClient discord, InteractiveServiceConfig config = null)
-            => new InteractiveService((BaseSocketClient)discord, config);
+            : this((BaseSocketClient)discord, config) {}
 
         public InteractiveService(BaseSocketClient discord, InteractiveServiceConfig config = null)
         {


### PR DESCRIPTION
The helper constructors were creating a new instance of the class instead of calling the main constructor.
This fixes #13.